### PR TITLE
Background overflow bug

### DIFF
--- a/assets/css/editor.css
+++ b/assets/css/editor.css
@@ -124,7 +124,6 @@
 
 .row-editor-top {
   display: flex;
-  flex-direction: row;
   margin-top: 4em;
   margin-bottom: -5em;
   width: 100%;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -263,7 +263,7 @@ div#contact-form {
 }
 
 /* actual contact form */
-form {
+form#contact-form-container {
   border: 1px solid transparent;
   border-radius: 6px;
   display: flex;

--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
               </div>
               
               <div id="contact-form">
-                <form action="#" method="POST">
+                <form action="#" method="POST" id="contact-form-container">
                   <input type="text" placeholder="First Name (required)" />
                   <input type="text" placeholder="Last Name (required)" />
                   <input type="email" placeholder="Email (required)" />


### PR DESCRIPTION
Fixes: #267 

## Background fixed of the slider inputs in the editor page

### Types of changes:
1. Added id to the contact form in index.html
2. Selected and styled the contact form using the id
3. Removed unncessary code from editor.css

### Why the bug was there?
Bug was there because the slider inputs are declared inside a form element and the contact form was also inside the form element, and the contact form was styled using the tag name not by any id, which results in styling of both "contact form" and "slider inputs" using same styles. Now the bug is fixed because the contact form is styled using the id.

### Before
![image](https://user-images.githubusercontent.com/49204837/96405762-a05f5d80-11fb-11eb-8aa5-a9849fc3a000.png)

### After
![image](https://user-images.githubusercontent.com/49204837/96405786-ab19f280-11fb-11eb-8358-d7d55f6e3763.png)


@smaranjitghose if you need styling on the background of input sliders then please let me know. I'll add it.