### PR TITLE
fixed download drop-down

### DIFF
--- a/assets/css/editor.css
+++ b/assets/css/editor.css
@@ -325,7 +325,6 @@
 
 @media (min-width: 994px) {
   .download-dropdown {
-    margin-left: 33em;
   }
 }
 


### PR DESCRIPTION
Fixes:#345 Download drop-down in the "Editor" section not working properly 

Before:
![bug](https://user-images.githubusercontent.com/64387054/104088383-87ab9480-528c-11eb-9e99-ec1e86d68d45.PNG)

after:
![fixed](https://user-images.githubusercontent.com/64387054/104088386-8ed2a280-528c-11eb-8a8e-65b4746e6010.PNG)

