### PR TITLE
Removed hove effect from navbar

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -40,13 +40,6 @@ nav {
   color: #ffffff !important;
 }
 
-
-.navbar-nav a:hover,
-.navbar-nav a:active {
-letter-spacing: 0px;
-background-color: rgba(255, 255, 255, 0.562) ;
-}
-
 .navbar-nav a:after,
 .navbar-nav a:before {
 backface-visibility: hidden;
@@ -59,21 +52,6 @@ position: relative;
 transition: all 280ms ease-in-out;
 width: 0;
 }
-
-.navbar-nav a:hover:after,
-.navbar-nav a:hover:before {
-backface-visibility: hidden;
-border-color: #fff;
-transition: width 350ms ease-in-out;
-width: 70%;
-}
-
-.navbar-nav a:hover:before {
-bottom: auto;
-top: 0;
-width: 70%;
-}
-
 
 .nav1 {
   height: 5em;


### PR DESCRIPTION
with the reference to the discussion on PR #374 (fixed download drop-down) for issue #345. 

Hover effect removed from the navbar of both pages

***before:***

![2021-01-09 (2)](https://user-images.githubusercontent.com/64387054/104104609-383a8800-52cf-11eb-9eae-f58b553740aa.png)

***after:***

![demo-hover](https://user-images.githubusercontent.com/64387054/104104620-44bee080-52cf-11eb-9ddc-6573c852344d.gif)
