### PR TITLE
[React] Sketch Page Added

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import "./index.css";
 
 const Home = lazy(() => import("./pages/Home/index"));
 const Editor = lazy(() => import("./pages/Editor/index"));
+const Sketch = lazy(() => import("./pages/Sketch/Sketch"));
 
 function App() {
   return (
@@ -15,6 +16,7 @@ function App() {
           <Header />
           <Route path="/" exact component={Home}></Route>
           <Route path="/editor" exact component={Editor}></Route>
+          <Route path="/sketch" exact component={Sketch}></Route>
         </Suspense>
       </Switch>
     </BrowserRouter>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -54,6 +54,9 @@ function Header() {
                 <NavLink className={styles.header_links} to='/editor' exact activeClassName={styles.header_active_links}>
                     Editor
                 </NavLink>
+                <NavLink className={styles.header_links} to='/sketch' exact activeClassName={styles.header_active_links}>
+                    Sketch <sup><span style={{color: "red", fontSize: "0.7rem"}}>New</span></sup>
+                </NavLink>
             </div>
         </header>
     )

--- a/src/pages/Sketch/Sketch.js
+++ b/src/pages/Sketch/Sketch.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import Canvas from './components/Canvas';
+import styles from './Sketch.module.css';
+
+function Sketch() {
+
+    return (
+        <section className={styles.Sketch}>
+            <div className={styles.title}>Sketch</div>
+            <div className={styles.body}>
+                <Canvas />
+            </div>
+        </section>
+    )
+}
+
+export default Sketch;

--- a/src/pages/Sketch/Sketch.module.css
+++ b/src/pages/Sketch/Sketch.module.css
@@ -1,0 +1,15 @@
+.Sketch {
+    background-color: rgb(240, 255, 255);
+    min-height: 89vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
+.title {
+    font-size: 2.1rem;
+    font-weight: bold;
+    font-family: cursive;
+    color: lightseagreen;
+}

--- a/src/pages/Sketch/components/Canvas.js
+++ b/src/pages/Sketch/components/Canvas.js
@@ -1,0 +1,116 @@
+import React, {useState, useEffect, useRef} from 'react';
+import styles from './Canvas.module.css';
+
+function Canvas() {
+
+    const canvasRef = useRef(null);
+    const [context, setContext] = useState();
+
+    function drawLine(info, style = {}) {
+        const { x, y, x1, y1 } = info;
+        const { color = 'tomato', width = 1 } = style;
+     
+        context.strokeStyle = color;
+        context.lineJoin = 'round';
+        context.lineWidth = width;
+        
+        context.beginPath();
+        context.moveTo(x, y);
+        context.lineTo(x1, y1);
+        context.closePath();
+        
+        context.stroke();
+      }
+
+    useEffect(() => {
+        setContext(canvasRef.current.getContext('2d'));
+    }, [])
+
+    const [isDrawing, setIsDrawing] = useState(false);
+    const [currentPoint, setCurrentPoint] = useState({x: "", y: ""});
+    const [mousePosition, setMousePosition] = useState({x: "0", y: "0"});
+
+    function relativeCoordinatesForEvent(event) {
+        return {
+          x: event.pageX - canvasRef.current.offsetLeft,
+          y: event.pageY - canvasRef.current.offsetTop,
+        };
+    }
+
+    function handleMouseDown(event) {
+        console.log(event);
+
+        if(event.button !== 0) {
+            return;
+        }
+
+        const point = relativeCoordinatesForEvent(event);
+
+        setIsDrawing(true);
+        setCurrentPoint(point);
+    }
+
+    function handleMouseMove(event) {
+        const point = relativeCoordinatesForEvent(event);
+        setMousePosition(point);
+
+        if(!isDrawing) {
+            return;
+        }
+
+        drawLine(
+            {
+                x: currentPoint.x,
+                y: currentPoint.y,
+                x1: point.x,
+                y1: point.y 
+            }
+        )
+        setCurrentPoint(point);
+    }
+
+    function handleMouseUp() {
+        setIsDrawing(false);
+    }
+
+    function handleMouseLeave() {
+        setIsDrawing(false);
+    }
+
+    function clear() {
+        context.clearRect(0, 0, canvasRef.current.width, canvasRef.current.height);
+    }
+
+    function download() {
+        let link = document.createElement('a');
+        link.download = 'drawing.png';
+        link.href = canvasRef.current.toDataURL("image/png");
+        link.click();
+    }
+
+    return (
+        <>
+            <div className={styles.options}>
+                <button className={`${styles.buttons} ${styles.btn_download}`}
+                    onClick={download}
+                >Download</button>
+                <button className={`${styles.buttons} ${styles.btn_clear}`}
+                    onClick={clear}
+                >Clear</button>
+            </div>
+            <canvas
+                ref={canvasRef}
+                width="700px"
+                height="500px"
+                className={styles.canvas}
+                onMouseDown={handleMouseDown}
+                onMouseMove={handleMouseMove}
+                onMouseUp={handleMouseUp}
+                onMouseLeave={handleMouseLeave}    
+            />
+            <div className={styles.mousePosition}>Mouse Position: (x, y) = ({mousePosition.x}, {mousePosition.y}) </div>
+        </>
+    )
+}
+
+export default Canvas

--- a/src/pages/Sketch/components/Canvas.module.css
+++ b/src/pages/Sketch/components/Canvas.module.css
@@ -1,0 +1,35 @@
+.canvas {
+    border: 3px solid blue;
+    border-radius: 11px;
+    margin: 11px;
+    background-color: white;
+    cursor: crosshair;
+}
+
+.options {
+    margin: 0 11px;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.buttons {
+    margin-right: 11px;
+    padding: 5px 7px;
+    color: white;
+    font-size: 0.9rem;
+    outline: none;
+    border-radius: 7px;
+}
+
+.btn_clear {
+    background-color: red;
+}
+
+.btn_download {
+    background-color: #219653;
+}
+
+.mousePosition {
+    margin: 0 11px;
+    font-size: 0.7rem;
+}


### PR DESCRIPTION
Issue #400 

✨ Sketch Page Implemented

1. Header Updated
2. Routes Added for Sketch Page
3. Sketch Page path = '/sketch'

**Features Till Now:**

1. Hand Drawing
2. Clear Drawing
3. Download Drawing as Image
4. Current Mouse Position

**Screenshots:**

- Header
![image](https://user-images.githubusercontent.com/43892590/105580738-2d462400-5db4-11eb-9fae-396cf1a9d94b.png)

- Sketch Page
![image](https://user-images.githubusercontent.com/43892590/105580851-ead11700-5db4-11eb-9daa-fc468387802c.png)

- Drawing
![image](https://user-images.githubusercontent.com/43892590/105580921-56b37f80-5db5-11eb-9b52-db19bff0e691.png)

- Downloaded Image
![image](https://user-images.githubusercontent.com/43892590/105582920-fcff8500-5db5-11eb-8368-bb140bb07a7d.png)

I would Like to contribute more to this. 😊 @smaranjitghose  @anushbhatia 
Thank You!