### PR TITLE
Download the sketch in a pdf format

### DIFF
--- a/src/pages/Sketch/components/Canvas.js
+++ b/src/pages/Sketch/components/Canvas.js
@@ -82,6 +82,16 @@ function Canvas() {
     }
 
     function download() {
+        // Download the doc in pdf format
+        const img = document.createElement("img");
+        const imgUrl = canvasRef.current.toDataURL("image/png");
+        img.src = imgUrl;
+
+        const pdfOptions = {
+          filename: "drawing.pdf",
+        };
+        DomToPdf(img, pdfOptions);
+
         let link = document.createElement('a');
         link.download = 'drawing.png';
         link.href = canvasRef.current.toDataURL("image/png");


### PR DESCRIPTION
The sketch is only downloaded in an img format, so I added these lines of code to download the sketch in a pdf file. Also, the `dom-to-pdf` dependency should be added to the project.