### PR TITLE
Top Home Section Responsive

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -5,9 +5,9 @@ import styles from './Header.module.css';
 import logo from './logo.png';
 import {ImInfo} from "react-icons/im";
 import {RiTeamLine, RiContactsBook2Line} from "react-icons/ri";
-import {BiDonateHeart} from "react-icons/bi";
+import {BiDonateHeart, BiMenu} from "react-icons/bi";
 
-const headerLinks = [
+const quickLinks = [
     {
         name: 'About',
         to: 'home_about',
@@ -59,10 +59,13 @@ function Header() {
                         Sketch <sup><span style={{color: "red", fontSize: "0.7rem"}}>New</span></sup>
                     </NavLink>
                 </div>
+                <div className={styles.hamburger}>
+                    <BiMenu size={30}/>
+                </div>
             </header>
             <div className={styles.quick_box}>
                 {
-                    location === '/' && headerLinks.map(link => (
+                    location === '/' && quickLinks.map(link => (
                         <Link className={styles.quick_links} key={link.name} to={link.to} offset={-100}>
                             {link.icon}
                             &nbsp;&nbsp;&nbsp;

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -1,7 +1,6 @@
 .Header {
     background-color: #103F5F;
     display: flex;
-    flex-wrap: wrap;
     justify-content: space-between;
     align-items: center;
     color: white;
@@ -23,6 +22,11 @@
     display: flex;
     justify-content: center;
     align-items: center;
+}
+
+.hamburger {
+    display: none;
+    cursor: pointer;
 }
 
 .header_links {
@@ -49,9 +53,9 @@
 
 .quick_box {
     position: fixed;
-    top: 0;
+    top: 50%;
     right: 0;
-    height: 100vh;
+    transform: translateY(-50%);
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -71,4 +75,14 @@
     text-decoration: none;
     background-color: #346d92;
     transform: translateX(0);
+}
+
+@media only screen and (max-width: 460px) {
+    .right {
+        display: none;
+    }
+
+    .hamburger {
+        display: block;
+    }
 }

--- a/src/pages/Home/sections/Banner/Banner.module.css
+++ b/src/pages/Home/sections/Banner/Banner.module.css
@@ -5,30 +5,30 @@
   background: linear-gradient(to right, #0f2027, #2c5364, #203a43);
   color: white;
   height: 89vh;
-  padding: 0 1rem;
+  padding: 1rem;
   padding-top: 3rem;
 }
 
 .content {
   display: flex;
+  justify-content: center;
+  align-items: center;
   width: 100%;
-  height: 100%;
+  padding: 1rem 5rem;
 }
 
 .text {
-  width: 60%;
-  height: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
+  width: 60%;
   text-align: center;
 }
 
 .text div {
   font-family: "Dancing Script", cursive;
-  font-size: 3.7rem;
-  width: 80%;
-  margin: 0 auto;
+  font-size: 4.85rem;
 }
 
 .button {
@@ -49,6 +49,7 @@
   margin-top: 15px;
   z-index: 1001;
 }
+
 .button:after {
   content: "";
   position: absolute;
@@ -59,6 +60,7 @@
   background-color: #05252c;
   z-index: -2;
 }
+
 .button:before {
   content: "";
   position: absolute;
@@ -70,10 +72,12 @@
   transition: all 0.3s;
   z-index: -1;
 }
+
 .button:hover {
   color: #fff;
   text-decoration: none;
 }
+
 .button:hover:before {
   width: 100%;
 }
@@ -82,11 +86,12 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 50%;
+  width: 40%;
+  margin-bottom: 1rem;
 }
 
 .image img {
-  width: 60%;
+  width: 300px;
 }
 
 .wave {
@@ -146,5 +151,46 @@
   }
   100% {
     background-position-x: -1000px;
+  }
+}
+
+
+@media only screen and (min-width: 600px) and (max-width: 970px) {
+  .content {
+    flex-direction: column-reverse;
+    margin: 0;
+    padding: 0 3rem;
+  }
+
+  .text {
+    width: 100%;
+  }
+
+  .text div {
+    font-size: 2.7rem;
+  }
+
+  .image img {
+    width: 230px;
+  }
+}
+
+@media only screen and (max-width: 600px) {
+  .content {
+    flex-direction: column-reverse;
+    margin: 0;
+    padding: 0 3rem;
+  }
+
+  .text {
+    width: 100%;
+  }
+
+  .text div {
+    font-size: 2.1rem;
+  }
+
+  .image img {
+    width: 170px;
   }
 }


### PR DESCRIPTION
Closes #464 

- Made Top Home Section Responsive
- Quick Box Height to `fit content` (Before, `Sketch` link was not clickable due to this)
- Renamed `headerLinks` to `quickLinks`

I would Like to make `Header` component responsive. If you allow me then I can do that in this same PR.

![topHomeSection_454](https://user-images.githubusercontent.com/43892590/107373795-eb83e000-6b0c-11eb-8a87-ddc144721903.gif)

I have participate in DWOC, SWOC and MWOC.