### PR TITLE
[performance] added preconnect tag to establish early connection to api.github.com

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
       content="A student's savior to submit those assignments by just typing them out and getting it handwritten on the go!"
       data-react-helmet="true"
     />
+    <link rel="preconnect" href="https://api.github.com">
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo.webp" />
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
Ref https://gtmetrix.com/preconnect-to-required-origins.html

now for downloading contibutors images from https://api.github.com/repos/smaranjitghose/doc2pen/contributors, the browser will establish an early connection with https://api.github.com/ to fetch the resource quickly when `fetch()` is called

adds to #476 

----------
_--I have participated in DWoC SWoC and MWoC_