### PR TITLE
update caching policy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,20 @@
 [[headers]]
   for = "*.js"  # for caching js files
   [headers.values]
-    Cache-Control = "public, max-age=7884000" # 3 months cache
+    Cache-Control = "public, max-age=34397077" # 1year 1month cache
 [[headers]]
   for = "*.css" # css files too
   [headers.values]
-    Cache-Control = "public, max-age=7884000"
+    Cache-Control = "public, max-age=34397077"
 [[headers]]
   for = "*.png" # png files too
   [headers.values]
-    Cache-Control = "public, max-age=7884000"
+    Cache-Control = "public, max-age=34397077"
+[[headers]]
+  for = "*.webp" # webp files too
+  [headers.values]
+    Cache-Control = "public, max-age=34397077"
+[[headers]]
+  for = "*.svg" # svg files too
+  [headers.values]
+    Cache-Control = "public, max-age=34397077"


### PR DESCRIPTION
**update caching policy for _webp_ and _svg_**

### increased cache TTL from 3months to 1year
![image](https://user-images.githubusercontent.com/60546840/107988945-f368d780-6f85-11eb-8ba6-09989d016c1e.png)
gtmetrix showed that having 91days(3months) cache TTL is not sufficient.  Then I further found that it said to have a minimum TTL of 1year. so I updated cache TTL from 3months to 1year


---------
_--I have participated in DWoC SWoC and MWoC_