### PR TITLE
add GH actions - auto assign reviewers

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,10 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+# Set to true to add assignees to pull requests
+addAssignees: false
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - smaranjitghose
+  - anushbhatia
+  
+

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,8 @@
+name: 'Auto Assign'
+on: pull_request
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.1.2
+


### PR DESCRIPTION
I have added the GitHub action to auto assign mentors for reviewal of pr.

Ref https://github.com/apps/auto-assign to install `auto-assign` github app

Ref [this README.md](https://github.com/kentaro-m/auto-assign-action/blob/master/README.md) for future reference

closes #523 


---------------------
_--I have participated in DWoC SWoC and MWoC_