### PR TITLE
Fixed padding to the editor (Issue #658)

### DIFF
--- a/src/pages/Editor/containers/editContext.js
+++ b/src/pages/Editor/containers/editContext.js
@@ -18,8 +18,9 @@ const EditContextProvider = props => {
 
   const [headValues, setHeadValues] = useState({
     headSize: null,
-    headTop: null,
-    headLeft: 0,
+    headTop: 20,
+    headLeft: 20,
+    headRight: 20,
     headLine: null,
     headFont: "HomemadeApple",
     headColor: "black",
@@ -28,8 +29,9 @@ const EditContextProvider = props => {
   });
   const [bodyValues, setBodyValues] = useState({
     bodySize: null,
-    bodyTop: null,
-    bodyLeft: 0,
+    bodyTop: 20,
+    bodyLeft: 20,
+    bodyRight: 20,
     bodyLine: null,
     bodyFont: "HomemadeApple",
     bodyColor: "black",

--- a/src/pages/Editor/sections/OutputComponent/Output.js
+++ b/src/pages/Editor/sections/OutputComponent/Output.js
@@ -31,6 +31,7 @@ const OutputComponent = () => {
             style={{
               fontSize: `${editContext.headValues.headSize}px`,
               paddingTop: `${editContext.headValues.headTop}px`,
+              paddingRight: `${Number(editContext.headValues.headRight) + 3}px`,
               paddingLeft: `${Number(editContext.headValues.headLeft) + 3}px`,
               lineHeight: `${editContext.headValues.headLine}`,
               fontFamily: `${editContext.headValues.headFont}`,
@@ -49,6 +50,7 @@ const OutputComponent = () => {
             style={{
               fontSize: `${editContext.bodyValues.bodySize}px`,
               paddingTop: `${editContext.bodyValues.bodyTop}px`,
+              paddingRight: `${Number(editContext.bodyValues.bodyRight) + 3}px`,
               paddingLeft: `${Number(editContext.bodyValues.bodyLeft) + 3}px`,
               lineHeight: `${editContext.bodyValues.bodyLine}`,
               fontFamily: `${editContext.bodyValues.bodyFont}`,


### PR DESCRIPTION
Added padding to the editor text to look better.

##Before
![Screenshot (398)](https://user-images.githubusercontent.com/59995879/111315964-dd375f80-8688-11eb-9d03-d7b8ade14105.png)

##After
![Screenshot (399)](https://user-images.githubusercontent.com/59995879/111316009-e6c0c780-8688-11eb-87b0-ecd3986330c7.png)

Would like to work on the second part of this issue.
