### PR TITLE
Canvas background Color Bug fixed

### DIFF
--- a/src/pages/Sketch/components/Canvas.js
+++ b/src/pages/Sketch/components/Canvas.js
@@ -375,7 +375,7 @@ function Canvas() {
     setCanvasStates([]);
     setcanvasStateAt(-1);
     setTypeState("");
-    setBackground("#ffffff")
+    setBackground("#ffffff");
   }
 
   function toggleIconLib() {
@@ -408,13 +408,8 @@ function Canvas() {
   }, [redo, undo]);
 
   useEffect(() => {
-    if (context) {
-      context.beginPath();
-      context.rect(0, 0, canvasWidth, canvasHeight);
-      context.fillStyle = background;
-      context.fill();
-    }
-  }, [background, context, canvasWidth, canvasHeight]);
+    canvasRef.current.style.background = background;
+  }, [background]);
 
   return (
     <>
@@ -508,8 +503,6 @@ function Canvas() {
       {/* icon library */}
     </>
   );
-
 }
-
 
 export default Canvas;


### PR DESCRIPTION
closes #765 

I removed the current method that changed the canvas background and then i implemented my own method

the problem with current method was that... when the color is selected.. the color is painted all over the canvas (i.e. the drawn stuff is painted with the new background)

BEFORE
![image](https://user-images.githubusercontent.com/60546840/112728741-ef659900-8ee5-11eb-94d4-dd925b48b76f.png)

AFTER
![image](https://user-images.githubusercontent.com/60546840/112728752-01473c00-8ee6-11eb-8fa5-c6d1bce130d0.png)


----------------------------------------
_- I have participated in GSSOC and CrossWoC_