### PR TITLE
Fixed: Width Bug in the Editor (Closes #798)

### DIFF
--- a/src/pages/Editor/containers/editContext.js
+++ b/src/pages/Editor/containers/editContext.js
@@ -36,7 +36,7 @@ const EditContextProvider = props => {
     bodyLine: null,
     bodyFont: "HomemadeApple",
     bodyColor: "black",
-    bodyWidth: null,
+    bodyWidth: 65,
     bodyLetterSpace: null,
     bodyText: "",
   });

--- a/src/pages/Editor/containers/editContext.js
+++ b/src/pages/Editor/containers/editContext.js
@@ -23,7 +23,7 @@ const EditContextProvider = props => {
     bodyLine: null,
     bodyFont: "HomemadeApple",
     bodyColor: "black",
-    bodyWidth: 65,
+    bodyWidth: 70,
     bodyLetterSpace: null,
     bodyText: "",
   });

--- a/src/pages/Editor/sections/OutputComponent/Output.js
+++ b/src/pages/Editor/sections/OutputComponent/Output.js
@@ -57,7 +57,7 @@ const OutputComponent = () => {
               lineHeight: `${editContext.bodyValues.bodyLine}`,
               fontFamily: `${editContext.bodyValues.bodyFont}`,
               color: `${editContext.bodyValues.bodyColor}`,
-              width: `${editContext.bodyValues.bodyWidth}pc`,
+              width: `${100*(editContext.bodyValues.bodyWidth)/70}%`,
               letterSpacing: `${editContext.bodyValues.bodyLetterSpace}px`,
               overflowY: "scroll",
             }}


### PR DESCRIPTION
closes #798 

The bug in the editor which allowed the user to increase the width to greater values than which that can be contained in the parent element has been fixed!
Before and After Images are attached below.
Before:
![image](https://user-images.githubusercontent.com/62770722/112864818-d3284e80-90d5-11eb-8347-1b5e85acbdaf.png)
After:
![Screenshot from 2021-03-29 21-25-28](https://user-images.githubusercontent.com/62770722/112864853-db808980-90d5-11eb-9edb-e4fe3bca440a.png)
