### PR TITLE
Fix: Word count feature in editor

### DIFF
--- a/src/pages/Editor/sections/OutputComponent/Output.js
+++ b/src/pages/Editor/sections/OutputComponent/Output.js
@@ -13,7 +13,7 @@ const OutputComponent = () => {
   const [wordCount, setWordCount] = useState(0);
 
   useEffect(() => {
-    setWordCount(pageText.split(/[\n| ]/).filter(c => c !== "").length);
+    setWordCount(pageText.split(/[\n|\t| ]/).filter(c => c !== "").length);
   }, [pageText]);
 
   return (

--- a/src/pages/Editor/sections/OutputComponent/Output.js
+++ b/src/pages/Editor/sections/OutputComponent/Output.js
@@ -13,7 +13,7 @@ const OutputComponent = () => {
   const [wordCount, setWordCount] = useState(0);
 
   useEffect(() => {
-    setWordCount(pageText.split(" ").filter(c => c !== "").length);
+    setWordCount(pageText.split(/[\n| ]/).filter(c => c !== "").length);
   }, [pageText]);
 
   return (


### PR DESCRIPTION
## Related Issue

- Major Bug in Word Count Feature in Editor

Closes: #820 

#### Describe the changes you've made

Currently, word count is only based on spaces between words, but not on newline (Enter) characters. This gives a wrong word count whenever the user uses the newline character (presses Enter)



## Screenshots

#### Before:

![113103182-cbd77280-91b3-11eb-852f-e2948b53df6c](https://user-images.githubusercontent.com/50210712/113161465-0a286c80-925c-11eb-9449-9bf916e26ec6.png)

#### After:
![firefox_iErt4kO27j](https://user-images.githubusercontent.com/50210712/113161583-25937780-925c-11eb-9abd-dc5417a61f57.png)

