### PR TITLE
Fixed Word Count: split by space, newline AND tab

### DIFF
--- a/src/pages/Editor/sections/OutputComponent/Output.js
+++ b/src/pages/Editor/sections/OutputComponent/Output.js
@@ -13,7 +13,7 @@ const OutputComponent = () => {
   const [wordCount, setWordCount] = useState(0);
 
   useEffect(() => {
-    setWordCount(pageText.split(" ").filter(c => c !== "").length);
+    setWordCount(pageText.split(/[\n|\t| ]/).filter(c => c !== "").length);
   }, [pageText]);
 
   return (


### PR DESCRIPTION
# Closes #820 (and improves upon)

## Changes made:
Earlier words were split only by space character. Now I've changed the argument passed to the split() method such that words are split on space( ), newline(\n) AND even tab(\t) character, which covers all the commonly used characters that separate words, leading to more accurate word count

## Before:
![image](https://user-images.githubusercontent.com/68962290/113190323-06232d00-9211-11eb-909a-e5013c55c128.png)


## After:
![image](https://user-images.githubusercontent.com/68962290/113190407-1affc080-9211-11eb-8eac-bd164f6493bb.png)

