### PR TITLE
[Bugfix]: #881 : Toolbox not scrolling anymore

### DIFF
--- a/src/pages/Sketch/components/Toolbox/toolbox.module.scss
+++ b/src/pages/Sketch/components/Toolbox/toolbox.module.scss
@@ -6,11 +6,14 @@
   left: 30px;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   background-color: colors.$white;
   border-radius: 5px;
   padding: 0.5rem;
   box-shadow: 0 0 3px 0.3px colors.$grey;
+  overflow-x: hidden;
+  overflow-y: auto;
+  height: 97%;
 
   .sliderWrapper {
     display: grid;


### PR DESCRIPTION
closes #881 

toolbox restored

# Before
![image](https://user-images.githubusercontent.com/60546840/114971099-8a3ffc00-9e30-11eb-96d2-9247421f3ccd.png)

# After
![image](https://user-images.githubusercontent.com/60546840/114970841-1271d180-9e30-11eb-9af2-5c80ff2814c9.png)
