### PR TITLE
Tooltips on review emojis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1742,9 +1742,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.1.tgz",
-      "integrity": "sha512-DvJbbn3dUgMxDnJLH+RZQPnXak1h4ZVYQ7CWiFWjQwBFkVajT4rfw2PdpHLTSTwxrYfnoEXkuBiwkDm6tPMQeA=="
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
+      "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q=="
     },
     "@react-leaflet/core": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "leaflet": "^1.7.1",
     "mousetrap": "^1.6.5",
     "react": "^17.0.1",
-    "react-bootstrap": "^1.4.3",
+    "react-bootstrap": "^1.5.2",
     "react-dom": "^17.0.1",
     "react-dropzone": "^11.3.2",
     "react-easy-emoji": "1.4.0",

--- a/src/pages/Home/sections/Contact/components/EmojiRating/EmojiRating.jsx
+++ b/src/pages/Home/sections/Contact/components/EmojiRating/EmojiRating.jsx
@@ -8,7 +8,7 @@ function EmojiRating() {
     
     {/*MODIFIED the emojis in the experience form*/}
     	
-    	/*Triggers Tooltips on hover*/
+    	{/*Triggers Tooltips on hover*/}
 		<OverlayTrigger
 			placement="top"
 			delay={{ show: 200, hide: 200 }}

--- a/src/pages/Home/sections/Contact/components/EmojiRating/EmojiRating.jsx
+++ b/src/pages/Home/sections/Contact/components/EmojiRating/EmojiRating.jsx
@@ -1,37 +1,68 @@
 import React from 'react'
 import styles from "./emoji-rating.module.scss";
+import { OverlayTrigger, Tooltip} from 'react-bootstrap';
 
 function EmojiRating() {
   return (
     <div className={styles.emojis}>
     
     {/*MODIFIED the emojis in the experience form*/}
-    
-    
-      <label>
-        <input className={styles.radio} type="radio" value="1" name="feedback" />
-        <span className={styles.emoji}>&#128077;</span>
-      </label>
+    	
+    	/*Triggers Tooltips on hover*/
+		<OverlayTrigger
+			placement="top"
+			delay={{ show: 200, hide: 200 }}
+			overlay=<Tooltip>Liked it</Tooltip>
+		>
+			<label>
+				<input className={styles.radio} type="radio" value="1" name="feedback" />
+				<span className={styles.emoji}>&#128077;</span>
+			</label>
+		</OverlayTrigger>
 
-      <label>
-        <input className={styles.radio} type="radio" value="2" name="feedback" />
-        <span className={styles.emoji}>&#128078;</span>
-      </label>
+		<OverlayTrigger
+			placement="top"
+			delay={{ show: 200, hide: 200 }}
+			overlay=<Tooltip>Dislike</Tooltip>
+		>
+			<label>
+				<input className={styles.radio} type="radio" value="2" name="feedback" />
+				<span className={styles.emoji}>&#128078;</span>
+			</label>
+		</OverlayTrigger>		
 
-      <label>
-        <input className={styles.radio} type="radio" value="3" name="feedback" />
-        <span className={styles.emoji}>&#128079;</span>
-      </label>
+		<OverlayTrigger
+			placement="top"
+			delay={{ show: 200, hide: 200 }}
+			overlay=<Tooltip>Appreciate</Tooltip>
+		>
+			<label>
+				<input className={styles.radio} type="radio" value="3" name="feedback" />
+				<span className={styles.emoji}>&#128079;</span>
+			</label>
+		</OverlayTrigger>
 
-      <label>
-        <input className={styles.radio} type="radio" value="4" name="feedback" />
-        <span className={styles.emoji}>&#128147;</span>
-      </label>
+		<OverlayTrigger
+			placement="top"
+			delay={{ show: 200, hide: 200 }}
+			overlay=<Tooltip>Loved it</Tooltip>
+		>
+			<label>
+				<input className={styles.radio} type="radio" value="4" name="feedback" />
+				<span className={styles.emoji}>&#128147;</span>
+			</label>
+		</OverlayTrigger>
 
-      <label>
-        <input className={styles.radio} type="radio" value="5" name="feedback" />
-        <span className={styles.emoji}>&#129327;</span>
-      </label>
+		<OverlayTrigger
+			placement="top"
+			delay={{ show: 200, hide: 200 }}
+			overlay=<Tooltip>Mind blowing</Tooltip>
+		>
+			<label>
+				<input className={styles.radio} type="radio" value="5" name="feedback" />
+				<span className={styles.emoji}>&#129327;</span>
+			</label>
+      </OverlayTrigger>
     </div>
   );
 }


### PR DESCRIPTION
I have made adequate changes to add tooltips on the review emojis. Kindly review the changes made by me.

Here is a snapshot when we hover over them: 

![tooltip_3](https://user-images.githubusercontent.com/53931981/115157375-8a493180-a0a6-11eb-85a5-91f48b8c23ee.JPG)
![tooltip_4](https://user-images.githubusercontent.com/53931981/115157377-8b7a5e80-a0a6-11eb-9454-4e85eb054779.JPG)
![tooltip_5](https://user-images.githubusercontent.com/53931981/115157378-8c12f500-a0a6-11eb-941b-08b05b444270.JPG)
