### PR TITLE
Added option for Bold Text in Editor

### DIFF
--- a/src/components/Dropdown/Dropdown.jsx
+++ b/src/components/Dropdown/Dropdown.jsx
@@ -34,9 +34,9 @@ const DropdownComponent = props => {
         {props.items.map((aItem, index) => (
           <DropdownItem
             onClick={getTargetFunc()}
-            name={props.type === "download" ? aItem : `body${props.type === "font" ? "Font" : "Color"}`}
+            name={props.type === "download" ? aItem : `body${props.type === "font" ? "Font" : props.type === "font-weight" ? "FontWeight" : "Color"}`}
             value={aItem}
-            style={{ "font-family": `${aItem}`, color: `${aItem}` }}
+            style={{ "font-family": `${aItem}`, color: `${aItem}`, "font-weight": `${aItem}` }}
             key={index}
           >
             {setValue(aItem)}
@@ -47,7 +47,7 @@ const DropdownComponent = props => {
   };
 
   const getTargetFunc = () => {
-    if (props.type === "font" || props.type === "color") return editContext.onValueChange;
+    if (props.type === "font" || props.type === "color" || props.type === "font-weight") return editContext.onValueChange;
     else if (props.type === "download") return editContext.downloadAction;
     return editContext.pageSrcHandler;
   };

--- a/src/pages/Editor/containers/editContext.js
+++ b/src/pages/Editor/containers/editContext.js
@@ -22,6 +22,7 @@ const EditContextProvider = props => {
     bodyRight: 20,
     bodyLine: null,
     bodyFont: "HomemadeApple",
+    bodyFontWeight: "normal",
     bodyColor: "black",
     bodyWidth: 70,
     bodyLetterSpace: null,

--- a/src/pages/Editor/sections/OutputComponent/Output.jsx
+++ b/src/pages/Editor/sections/OutputComponent/Output.jsx
@@ -36,6 +36,7 @@ const OutputComponent = () => {
               paddingLeft: `${Number(editContext.bodyValues.bodyLeft) + 3}px`,
               lineHeight: `${editContext.bodyValues.bodyLine}`,
               fontFamily: `${editContext.bodyValues.bodyFont}`,
+              fontWeight: `${editContext.bodyValues.bodyFontWeight}`,
               color: `${editContext.bodyValues.bodyColor}`,
               width: `${(100 * editContext.bodyValues.bodyWidth) / 70}%`,
               letterSpacing: `${editContext.bodyValues.bodyLetterSpace}px`,

--- a/src/pages/Editor/sections/Settings/Settings.jsx
+++ b/src/pages/Editor/sections/Settings/Settings.jsx
@@ -56,6 +56,16 @@ const Settings = () => {
           />
           <Divider orientation="vertical" flexItem />
           <Dropdown
+            name="Change Font Weight"
+            type="font-weight"
+            items={[
+              "normal",
+              "bold"
+            ]}
+            active={editContext.bodyValues.bodyFontWeight}
+          />
+          <Divider orientation="vertical" flexItem />
+          <Dropdown
             name="Change Sheet"
             type="page"
             active={editContext.pageSrc}


### PR DESCRIPTION
## Fixes #932 

## Description:
- Re-used the dropdown component to create a new one for controlling font-weight in `Settings`.
- Added `bodyFontWeight` as an option to the `editContext` and implemented it in the `Output` section
- Customized the functionality and styling of `DropdownItem` for this new option

## Screenshots:
- Output when bold is chosen:
![image](https://user-images.githubusercontent.com/68962290/118380585-bf5a7e00-b597-11eb-998b-6118e3ad00ca.png)

- Dropdown Menu for Font Weight:
![image](https://user-images.githubusercontent.com/68962290/118380610-f597fd80-b597-11eb-8f9e-39aa2b60e799.png)
