### PR TITLE
Hide Dropdown on changing Route / Page on Mobile

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -63,6 +63,7 @@ function Header() {
         <NavLink
           to="/"
           onClick={() => {
+            if(headerRef.current.classList.contains(styles.HeaderOpen)) drop()
             window.isHome = false;
           }}
         >
@@ -75,6 +76,7 @@ function Header() {
             exact
             activeClassName={styles.header_active_links}
             onClick={() => {
+              if(headerRef.current.classList.contains(styles.HeaderOpen)) drop()
               window.isHome = false;
             }}
           >
@@ -86,6 +88,7 @@ function Header() {
             exact
             activeClassName={styles.header_active_links}
             onClick={() => {
+              if(headerRef.current.classList.contains(styles.HeaderOpen)) drop()
               window.isHome = false;
             }}
           >
@@ -97,6 +100,7 @@ function Header() {
             exact
             activeClassName={styles.header_active_links}
             onClick={() => {
+              if(headerRef.current.classList.contains(styles.HeaderOpen)) drop()
               window.isHome = false;
             }}
           >
@@ -108,6 +112,7 @@ function Header() {
             exact
             activeClassName={styles.header_active_links}
             onClick={() => {
+              if(headerRef.current.classList.contains(styles.HeaderOpen)) drop()
               window.isHome = false;
             }}
           >


### PR DESCRIPTION
## Fixes #945 

## Description
- on clicking any navigation link, checked if the dropdown menu was open / visible, and if yes, toggled classes using the predefined `drop()` function to hide it