### PR TITLE
Implemented add/remove page buttons, also added page number display

### DIFF
--- a/src/pages/Editor/Editor.jsx
+++ b/src/pages/Editor/Editor.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useState, useEffect } from "react";
 
 import styles from "./style.module.scss";
 
@@ -11,8 +11,11 @@ import Settings from "./sections/Settings/Settings.jsx";
 import Output from "./sections/OutputComponent/Output";
 
 import ScrollToTop from "../../components/ScrollToTopButton/ScrollToTopButton";
+import { Button } from "reactstrap"
 
 function Editor() {
+  const [pageCount, setPageCount] = useState(1)
+
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
@@ -27,11 +30,15 @@ function Editor() {
       <div className={styles.dscCommunity}>
         <EditContextProvider>
           <Settings />
-          <Output />
+          {[...Array(pageCount)].map((e,i) => <Output key={i} pageNo={i+1} />)}          
         </EditContextProvider>
       </div>
       <div className={styles.btnWrapper}>
         <ScrollToTop />
+      </div>
+      <div className={styles.pageBtnsWrapper}>
+        <Button outline color="primary" onClick={() => setPageCount(prev => prev+1)}>Add Page</Button>
+        <Button outline color="primary" disabled={pageCount===1} onClick={() => setPageCount(prev => prev-1)}>Remove Last Page</Button>
       </div>
     </>
   );

--- a/src/pages/Editor/sections/OutputComponent/Output.jsx
+++ b/src/pages/Editor/sections/OutputComponent/Output.jsx
@@ -3,7 +3,7 @@ import { useContext, useState, useEffect } from "react";
 import classes from "./output.module.scss";
 import { EditContext } from "../../containers/editContext";
 
-const OutputComponent = () => {
+const OutputComponent = ({ pageNo }) => {
   const editContext = useContext(EditContext);
   const page = require(`./${editContext.pageSrc}`);
   console.log(`${editContext.pageSrc}`);
@@ -24,7 +24,6 @@ const OutputComponent = () => {
           </div>
           <textarea
             type="text"
-            value={editContext.bodyValues.textValue}
             onChange={e => setPageText(e.target.value)}
             className={`${classes.contentInput} id-body`}
             id="show-text"
@@ -44,9 +43,15 @@ const OutputComponent = () => {
             }}
           />
         </div>
-        <div style={{ fontSize: "0.75rem", marginTop: "11px", fontWeight: "bold" }}>
-          Word Count:&nbsp;
-          <span style={{ color: "#28b8c6", fontSize: "0.85rem" }}>{wordCount}</span>
+        <div style={{ fontSize: "0.75rem", marginTop: "11px", fontWeight: "bold", display: "flex", justifyContent: "space-between" }}>
+          <div>
+            Word Count:&nbsp;
+            <span style={{ color: "#28b8c6", fontSize: "0.85rem" }}>{wordCount}</span>
+          </div>
+          <div>
+            Page Number:&nbsp;
+            <span style={{ color: "#28b8c6", fontSize: "0.85rem" }}>{pageNo}</span>
+          </div>
         </div>
       </div>
     </>

--- a/src/pages/Editor/style.module.scss
+++ b/src/pages/Editor/style.module.scss
@@ -16,6 +16,16 @@ label {
   }
 }
 
+.pageBtnsWrapper {
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
+}
+
+.pageBtnsWrapper > * {
+  margin: 10px;
+}
+
 /* ----- Commenting this custom range as we are not using this any more, also it was affecting the range input in Sketch Section ----- */
 
 /* input[type="range"] {


### PR DESCRIPTION
## Fixes #955 

## Changes made:
- Added a state variable for `pageCount`
- Implemented a button that increments `pageCount` by 1
- Implemented a button that decrements `pageCount` by 1 which is disabled if `pageCount!==1`
- Styled both buttons using reactstrap `Button` component
- Repeat the `Output` component `pageCount` number of times
- Passed a `pageNo` prop to the `Output` component, to display page number along with word count
- Styled page number like word count


## Screenshot:
![image](https://user-images.githubusercontent.com/68962290/119338440-d9a1f500-bc44-11eb-84d5-ea3d167d3dc4.png)
