### PR TITLE
Implemented Export as both PNG and PDF for Multipage Documents

### DIFF
--- a/src/pages/Editor/Editor.jsx
+++ b/src/pages/Editor/Editor.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useState, useEffect } from "react";
 
 import styles from "./style.module.scss";
 
@@ -11,8 +11,11 @@ import Settings from "./sections/Settings/Settings.jsx";
 import Output from "./sections/OutputComponent/Output";
 
 import ScrollToTop from "../../components/ScrollToTopButton/ScrollToTopButton";
+import { Button } from "reactstrap"
 
 function Editor() {
+  const [pageCount, setPageCount] = useState(1)
+
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
@@ -27,11 +30,15 @@ function Editor() {
       <div className={styles.dscCommunity}>
         <EditContextProvider>
           <Settings />
-          <Output />
+          {[...Array(pageCount)].map((e,i) => <Output key={i} pageNo={i+1} />)}          
         </EditContextProvider>
       </div>
       <div className={styles.btnWrapper}>
         <ScrollToTop />
+      </div>
+      <div className={styles.pageBtnsWrapper}>
+        <Button outline color="primary" onClick={() => setPageCount(prev => prev+1)}>Add Page</Button>
+        <Button outline color="primary" disabled={pageCount===1} onClick={() => setPageCount(prev => prev-1)}>Remove Last Page</Button>
       </div>
     </>
   );

--- a/src/pages/Editor/sections/OutputComponent/Output.jsx
+++ b/src/pages/Editor/sections/OutputComponent/Output.jsx
@@ -3,7 +3,7 @@ import { useContext, useState, useEffect } from "react";
 import classes from "./output.module.scss";
 import { EditContext } from "../../containers/editContext";
 
-const OutputComponent = () => {
+const OutputComponent = ({ pageNo }) => {
   const editContext = useContext(EditContext);
   const page = require(`./${editContext.pageSrc}`);
   console.log(`${editContext.pageSrc}`);
@@ -24,7 +24,6 @@ const OutputComponent = () => {
           </div>
           <textarea
             type="text"
-            value={editContext.bodyValues.textValue}
             onChange={e => setPageText(e.target.value)}
             className={`${classes.contentInput} id-body`}
             id="show-text"
@@ -44,9 +43,15 @@ const OutputComponent = () => {
             }}
           />
         </div>
-        <div style={{ fontSize: "0.75rem", marginTop: "11px", fontWeight: "bold" }}>
-          Word Count:&nbsp;
-          <span style={{ color: "#28b8c6", fontSize: "0.85rem" }}>{wordCount}</span>
+        <div style={{ fontSize: "0.75rem", marginTop: "11px", fontWeight: "bold", display: "flex", justifyContent: "space-between" }}>
+          <div>
+            Word Count:&nbsp;
+            <span style={{ color: "#28b8c6", fontSize: "0.85rem" }}>{wordCount}</span>
+          </div>
+          <div>
+            Page Number:&nbsp;
+            <span style={{ color: "#28b8c6", fontSize: "0.85rem" }}>{pageNo}</span>
+          </div>
         </div>
       </div>
     </>

--- a/src/pages/Editor/sections/OutputComponent/Output.jsx
+++ b/src/pages/Editor/sections/OutputComponent/Output.jsx
@@ -18,7 +18,7 @@ const OutputComponent = ({ pageNo }) => {
   return (
     <>
       <div className={`${classes.wrapper} col-11 col-lg-8 mx-auto mt-4 p-2`}>
-        <div id="outputPage" className={`col-12 mx-auto px-0`}>
+        <div id="outputPage" className={`outputPage col-12 mx-auto px-0`}>
           <div className={`${classes.imgContainer} col-12 mx-auto px-0`}>
             <img src={page.default} alt="editor" className="mx-auto px-0" Width="100%" Height="100%" />
           </div>

--- a/src/pages/Editor/style.module.scss
+++ b/src/pages/Editor/style.module.scss
@@ -16,6 +16,16 @@ label {
   }
 }
 
+.pageBtnsWrapper {
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
+}
+
+.pageBtnsWrapper > * {
+  margin: 10px;
+}
+
 /* ----- Commenting this custom range as we are not using this any more, also it was affecting the range input in Sketch Section ----- */
 
 /* input[type="range"] {


### PR DESCRIPTION
### **Please merge PR #957 before this as this branch is checked out from the #957 branch**

## Fixes #958 

## Changes made:
- for downloading, got all the `outputPage` DOM elements.
- looped through all of them and made a dataUrl from each.
- For PNG:
  - if there is a single page, exported 1 image with the user given file name
  - for multiple pages, exported an image for each page with the name being the user given file name followed by a hyphen and the page number. (example: user chose name doc for a 3 page document, so images generated will be doc-0.png, doc-1.png and doc-2.png)
- For PDF
  - created an array of all the dataUrls from all the pages' images
  - looped through this array, and added a new page in the pdf for each image
  - saved this single pdf by the user given file name