### PR TITLE
Fixed Multiple Files Conversion Bug

### DIFF
--- a/src/pages/MediaManip/MediaManip.jsx
+++ b/src/pages/MediaManip/MediaManip.jsx
@@ -66,8 +66,8 @@ export default function MediaManip() {
   const convertImage = format => {
     startConversion();
     let img = new Image();
-    let canvas = document.createElement("canvas");
     files.forEach(item => {
+      let canvas = document.createElement("canvas");
       img.src = item.preview;
       canvas.width = img.width;
       canvas.height = img.height;


### PR DESCRIPTION
## Fixes #981 

Multiple files' simultaneous conversion and download now behaves as expected

(After lots of `console.log()`ing and inspecting, I found that the bug was due to the scoping of canvas element combined with the slow `toDataUrl()` method)