### PR TITLE
Implemented Buttons to Toggle between Pages

### DIFF
--- a/src/pages/Editor/Editor.jsx
+++ b/src/pages/Editor/Editor.jsx
@@ -19,7 +19,7 @@ function Editor() {
 
   useEffect(() => {
     if(currentPageNo > pageCount) setCurrentPageNo(prev => prev-1);
-  }, [pageCount])
+  }, [pageCount, currentPageNo])
 
   useEffect(() => {
     window.scrollTo(0, 0);

--- a/src/pages/Editor/Editor.jsx
+++ b/src/pages/Editor/Editor.jsx
@@ -15,6 +15,11 @@ import { Button } from "reactstrap"
 
 function Editor() {
   const [pageCount, setPageCount] = useState(1)
+  const [currentPageNo, setCurrentPageNo] = useState(1)
+
+  useEffect(() => {
+    if(currentPageNo > pageCount) setCurrentPageNo(prev => prev-1);
+  }, [pageCount])
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -30,14 +35,18 @@ function Editor() {
       <div className={styles.dscCommunity}>
         <EditContextProvider>
           <Settings />
-          {[...Array(pageCount)].map((e,i) => <Output key={i} pageNo={i+1} />)}          
+          <div className={styles.pageBtnsWrapper}>
+            <Button outline color="primary" disabled={currentPageNo===1} onClick={() => setCurrentPageNo(prev => prev-1)}>Previous Page</Button>
+            <Button outline color="primary" disabled={currentPageNo===pageCount} onClick={() => setCurrentPageNo(prev => prev+1)}>Next Page</Button>
+          </div>
+          {[...Array(pageCount)].map((e,i) => <Output key={i+1} pageNo={i+1} show={(i+1)===currentPageNo} />)}          
         </EditContextProvider>
       </div>
       <div className={styles.btnWrapper}>
         <ScrollToTop />
       </div>
       <div className={styles.pageBtnsWrapper}>
-        <Button outline color="primary" onClick={() => setPageCount(prev => prev+1)}>Add Page</Button>
+        <Button outline color="primary" onClick={() => setPageCount(prev => prev+1)}>Add Page at the End</Button>
         <Button outline color="primary" disabled={pageCount===1} onClick={() => setPageCount(prev => prev-1)}>Remove Last Page</Button>
       </div>
     </>

--- a/src/pages/Editor/sections/OutputComponent/Output.jsx
+++ b/src/pages/Editor/sections/OutputComponent/Output.jsx
@@ -3,7 +3,7 @@ import { useContext, useState, useEffect } from "react";
 import classes from "./output.module.scss";
 import { EditContext } from "../../containers/editContext";
 
-const OutputComponent = ({ pageNo }) => {
+const OutputComponent = ({ pageNo, show }) => {
   const editContext = useContext(EditContext);
   const page = require(`./${editContext.pageSrc}`);
   console.log(`${editContext.pageSrc}`);
@@ -17,7 +17,7 @@ const OutputComponent = ({ pageNo }) => {
 
   return (
     <>
-      <div className={`${classes.wrapper} col-11 col-lg-8 mx-auto mt-4 p-2`}>
+      <div className={`${classes.wrapper} col-11 col-lg-8 mx-auto mt-4 p-2`} style={{display: show ? "block" : "none"}}>
         <div id="outputPage" className={`outputPage col-12 mx-auto px-0`}>
           <div className={`${classes.imgContainer} col-12 mx-auto px-0`}>
             <img src={page.default} alt="editor" className="mx-auto px-0" Width="100%" Height="100%" />


### PR DESCRIPTION
## Fixes #983 

## Changes Made:
- Added a state variable for `currentPageNo`
- Implemented a next page button which increments `currentPageNo` by 1 (disabled if `currentPageNo===pageCount`)
- Implemented a previous page button which decrements `currentPageNo` by 1 (disabled if `currentPageNo===1`)
- Only display the Output component if its associated `pageNo=currentPageNo` using a boolean `show` prop
- Made sure that if the user removes the last page while it is active, `currentPageNo` is switched to its previous page 

## Screenshot:
![image](https://user-images.githubusercontent.com/68962290/119892666-48a27680-beef-11eb-9624-4b5a21cca285.png)
