### PR TITLE
Made it possible for user to drag and drop files multiple times

### DIFF
--- a/src/pages/MediaManip/DragDrop/DragDrop.jsx
+++ b/src/pages/MediaManip/DragDrop/DragDrop.jsx
@@ -53,16 +53,14 @@ function DragDrop(props) {
           ))}
         </div>
       )}
-      {files.length === 0 && (
-        <div {...getRootProps({ className: "dropzone" })} className={styles.container_upload}>
-          <input {...getInputProps()} />
-          {isDragActive ? (
-            <p>Drop the files here ...</p>
-          ) : (
-            <p>Drag 'n' drop some files here, or click to select files</p>
-          )}
-        </div>
-      )}
+      <div {...getRootProps({ className: "dropzone" })} className={styles.container_upload}>
+        <input {...getInputProps()} />
+        {isDragActive ? (
+          <p>Drop the files here ...</p>
+        ) : (
+          <p>Drag 'n' drop some files here, or click to select files</p>
+        )}
+      </div>
     </section>
   );
 }

--- a/src/pages/MediaManip/DragDrop/drag-drop.module.scss
+++ b/src/pages/MediaManip/DragDrop/drag-drop.module.scss
@@ -5,12 +5,11 @@
   margin: 2rem auto;
   border: 2px solid #cccccc;
   display: flex;
-  justify-content: flex-start;
+  // justify-content: flex-start;
   border-radius: 5px;
 
   &_image {
-    width: 90%;
-    flex: 1 0 auto;
+    width: Min(Calc(100% - 150px), max-content);
     margin: 10px;
     padding: 8px;
     display: flex;
@@ -20,10 +19,12 @@
   }
 
   &_upload {
-    width: 100%;
     margin: 16px;
     border: 3px dashed #cccccc;
     padding: 10px;
+    min-width: 150px;
+    width: 150px;
+    flex-grow: 1;
     display: flex;
     justify-content: center;
     align-items: center;

--- a/src/pages/MediaManip/MediaManip.jsx
+++ b/src/pages/MediaManip/MediaManip.jsx
@@ -66,8 +66,8 @@ export default function MediaManip() {
   const convertImage = format => {
     startConversion();
     let img = new Image();
-    let canvas = document.createElement("canvas");
     files.forEach(item => {
+      let canvas = document.createElement("canvas");
       img.src = item.preview;
       canvas.width = img.width;
       canvas.height = img.height;
@@ -83,7 +83,7 @@ export default function MediaManip() {
       });
     });
   };
-
+  
   const onDownload = () => {
     convertedFiles.forEach((item, index) => {
       zip.file(`${index}.${item.type}`, item.data, { base64: true });


### PR DESCRIPTION
## Fixes #963 

## Changes made:
- Dropzone area is always rendered, to allow unlimited file drops
- Styled the file preview to expand horizontally as its content increases till a limit, and then scroll
- Styled the dropzone to take as much space as left beside the file preview but have a minimum width for easy drop

## Screenshots:
- Without scroll
![image](https://user-images.githubusercontent.com/68962290/119940229-bd070500-bf43-11eb-9e8a-297892a7c870.png)
- With scroll
![image](https://user-images.githubusercontent.com/68962290/119940296-d445f280-bf43-11eb-8fd7-f26f3cec6b72.png)

