### PR TITLE
Fixed Multiple Page Exports Bug (Both PNG and PDF format)

### DIFF
--- a/src/pages/Editor/components/DownloadFileModal/DownloadFileModal.jsx
+++ b/src/pages/Editor/components/DownloadFileModal/DownloadFileModal.jsx
@@ -11,6 +11,7 @@ const DownloadFileModal = props => {
   const handleDownloadFile = e => {
     if (!value) setValueError("please provide file name");
     else {
+      editContext.setAllPagesVisible(true);
       editContext.downloadAction(value, fileType);
       setModal(false);
       setValue("");

--- a/src/pages/Editor/containers/editContext.js
+++ b/src/pages/Editor/containers/editContext.js
@@ -29,6 +29,8 @@ const EditContextProvider = props => {
     bodyText: "",
   });
 
+  const [allPagesVisible, setAllPagesVisible] = useState(false);
+
   const [show, setShow] = useState(false);
   const [showing, setShowing] = useState(false);
 
@@ -77,15 +79,21 @@ const EditContextProvider = props => {
         const img = new Image();
         img.src = dataUrl;
         const fileName = multiple ? `${baseFileName}-${index}.png` : `${baseFileName}.png`
+        dataUrls.push(dataUrl);
         if (type === "PNG") {
           downloadURI(dataUrl, fileName);
         } else if (type === "PDF") {
-          dataUrls.push(dataUrl);
-          if(index===nodes.length-1) downloadPdf(dataUrls, baseFileName);
+          if(dataUrls.length === nodes.length) downloadPdf(dataUrls, baseFileName);
         }
       })
       .catch(error => {
         console.error("oops,something went wrong", error);
+      })
+      .finally(() => {
+        if(dataUrls.length === nodes.length) {
+          console.log("converted")
+          setAllPagesVisible(false)
+        }
       })
     );
   };
@@ -108,7 +116,6 @@ const EditContextProvider = props => {
     // }, 2000);
   };
   const downloadPdf = async (imgDataUris, name) => {
-    console.log(imgDataUris);
     const doc = new jsPDF("p", "pt", "a4");
     const width = doc.internal.pageSize.width;
     const height = doc.internal.pageSize.height;
@@ -176,6 +183,8 @@ const EditContextProvider = props => {
         downloadAction,
         pageSrcHandler,
         importTxt,
+        allPagesVisible,
+        setAllPagesVisible
       }}
     >
       {props.children}

--- a/src/pages/Editor/sections/OutputComponent/Output.jsx
+++ b/src/pages/Editor/sections/OutputComponent/Output.jsx
@@ -11,13 +11,15 @@ const OutputComponent = ({ pageNo, show }) => {
   const [pageText, setPageText] = useState("");
   const [wordCount, setWordCount] = useState(0);
 
+  const { allPagesVisible } = editContext;
+
   useEffect(() => {
     setWordCount(pageText.split(/[\n|\t| ]/).filter(c => c !== "").length);
   }, [pageText]);
 
   return (
     <>
-      <div className={`${classes.wrapper} col-11 col-lg-8 mx-auto mt-4 p-2`} style={{display: show ? "block" : "none"}}>
+      <div className={`${classes.wrapper} col-11 col-lg-8 mx-auto mt-4 p-2`} style={{display: show || allPagesVisible ? "block" : "none"}}>
         <div id="outputPage" className={`outputPage col-12 mx-auto px-0`}>
           <div className={`${classes.imgContainer} col-12 mx-auto px-0`}>
             <img src={page.default} alt="editor" className="mx-auto px-0" Width="100%" Height="100%" />


### PR DESCRIPTION
## Fixes #986 

## Before:
Either the file download would completely fail or only the active page would be downloaded

## After:
The complete file, as expected, is downloaded, and while downloading all the pages are visible. Once download completes, again only the current active page is made visible