### PR TITLE
Added Feature to Directly Navigate to any Page by it's Number on Editor Page

### DIFF
--- a/src/pages/Editor/Editor.jsx
+++ b/src/pages/Editor/Editor.jsx
@@ -11,7 +11,7 @@ import Settings from "./sections/Settings/Settings.jsx";
 import Output from "./sections/OutputComponent/Output";
 
 import ScrollToTop from "../../components/ScrollToTopButton/ScrollToTopButton";
-import { Button } from "reactstrap";
+import { Button, Input, Label } from "reactstrap";
 
 function Editor() {
 	const [pageCount, setPageCount] = useState(1);
@@ -44,6 +44,9 @@ function Editor() {
 						>
 							Previous Page
 						</Button>
+						<Label>Current Page No.
+							<Input type="number" max={pageCount} min="1" step="1" value={currentPageNo} onInput={(e)=>setCurrentPageNo(parseInt(e.target.value))}/>
+						</Label>
 						<Button
 							outline
 							color="primary"


### PR DESCRIPTION
## Fixes #1012 

## Changes Made:
- Added an `input` of type `number` with range same as the `pageCount`
- Made it reactive so as soon as the user enters a number, the `currentPageNo` state variable is set to that.

## Screenshot:
![image](https://user-images.githubusercontent.com/68962290/120122194-36794000-c15c-11eb-80ce-c81277ad9ee3.png)
