### PR TITLE
Bug Fix: PDF files can only be merged, other format options should not show in Output dropdown

### DIFF
--- a/src/pages/MediaManip/DragDrop/DragDrop.jsx
+++ b/src/pages/MediaManip/DragDrop/DragDrop.jsx
@@ -27,7 +27,7 @@ function DragDrop(props) {
 					outputOptionsTemp.splice(index, 1);
 					setOutputOptions(outputOptionsTemp);
 				}
-
+				if(fileType === "pdf") setOutputOptions(["pdf"]);
 				return Object.assign(file, {
 					preview: URL.createObjectURL(file),
 				});


### PR DESCRIPTION
## Problem:
Currently, when PDF files were selected, other image formats still showed up as conversion options. Chosing them would make nothing happen, so no error, but giving false options is bad UX

## Solution:
When a PDF file is selected, user only is only shown the PDF option to merge them

## Changes Made:
I've added a condition which sets output options to only PDF when a PDF file is dropped by the user