### PR TITLE
Fixed Editor Page Text Layout

### DIFF
--- a/src/pages/Editor/containers/editContext.js
+++ b/src/pages/Editor/containers/editContext.js
@@ -46,6 +46,15 @@ const EditContextProvider = props => {
 
 	const pageSrcHandler = e => {
 		setPageSrc(`${ImageNameMap[e.target.value]}`);
+		if (e.target.value == "Ruled1"){
+			setBodyValues({ ...bodyValues, ["bodyLeft"]: 135,["bodyTop"]: 144 });
+		}
+		else if(e.target.value == "Ruled2"){
+			setBodyValues({ ...bodyValues, ["bodyLeft"]: 115,["bodyTop"]: 132 });
+		}
+		else if(e.target.value == "OnlyMargin"){
+			setBodyValues({ ...bodyValues, ["bodyLeft"]: 115,["bodyTop"]: 125 });
+		}
 	};
 
 	const onValueChange = e => {

--- a/src/pages/Editor/sections/Settings/Settings.jsx
+++ b/src/pages/Editor/sections/Settings/Settings.jsx
@@ -119,7 +119,7 @@ const Settings = () => {
 					editContext={editContext}
 					name="bodyTop"
 					min="0"
-					max="100"
+					max="200"
 					step={1}
 					initialValue={5}
 				/>


### PR DESCRIPTION
Resolves #1076 

Updated range of "Adjust-y-axis" from 0 to 100 to 0 to 200.

Corrected the text alignment for pages - Ruled1, Ruled2 and OnlyMargin

POC - [https://youtu.be/rGZoIDYc9Qg](url)

